### PR TITLE
Add an architecture test that checks exception raising

### DIFF
--- a/src/test/java/edu/hm/hafner/util/ArchitectureTest.java
+++ b/src/test/java/edu/hm/hafner/util/ArchitectureTest.java
@@ -32,4 +32,7 @@ class ArchitectureTest {
 
     @ArchTest
     static final ArchRule NO_FORBIDDEN_ANNOTATION_USED = ArchitectureRules.NO_FORBIDDEN_ANNOTATION_USED;
+
+    @ArchTest
+    static final ArchRule NO_EXCEPTIONS_WITH_NO_ARG_CONSTRUCTOR = ArchitectureRules.NO_EXCEPTIONS_WITH_NO_ARG_CONSTRUCTOR;
 }


### PR DESCRIPTION
When a new exception is raised then the no-arg constructor of the exception must never be called. Otherwise the context
of the failure is missing. 

See **Effective Java** (Item 75): Include failure-capture information in detail messages.