### PR TITLE
Add tests that verify some ArchUnit rules

### DIFF
--- a/src/test/java/edu/hm/hafner/util/ArchitectureRulesTest.java
+++ b/src/test/java/edu/hm/hafner/util/ArchitectureRulesTest.java
@@ -1,0 +1,51 @@
+package edu.hm.hafner.util;
+
+import org.junit.jupiter.api.Test;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Verifies the architecture rules in {@link ArchitectureRules}.
+ *
+ * @author Ullrich Hafner
+ */
+class ArchitectureRulesTest {
+    @Test
+    void shouldVerifyNoPublicTestClassesRule() {
+        JavaClasses violatedClasses = importClasses(NoPublicTestElementsViolatedTest.class);
+        assertThatExceptionOfType(AssertionError.class).isThrownBy(
+                () -> ArchitectureRules.NO_PUBLIC_TEST_CLASSES.check(violatedClasses));
+        JavaClasses passedClasses = new ClassFileImporter().importClasses(NoPublicTestElementsPassedTest.class);
+        assertThatNoException().isThrownBy(
+                () -> ArchitectureRules.NO_PUBLIC_TEST_CLASSES.check(passedClasses));
+    }
+
+    @Test
+    void shouldVerifyNoPublicTestMethodsRule() {
+        JavaClasses violatedClasses = importClasses(NoPublicTestElementsViolatedTest.class);
+        assertThatExceptionOfType(AssertionError.class).isThrownBy(
+                () -> ArchitectureRules.ONLY_PACKAGE_PRIVATE_TEST_METHODS.check(violatedClasses));
+        JavaClasses passedClasses = new ClassFileImporter().importClasses(NoPublicTestElementsPassedTest.class);
+        assertThatNoException().isThrownBy(
+                () -> ArchitectureRules.ONLY_PACKAGE_PRIVATE_TEST_METHODS.check(passedClasses));
+    }
+
+    private JavaClasses importClasses(final Class<?>... classes) {
+        return new ClassFileImporter().importClasses(classes);
+    }
+
+    public static class NoPublicTestElementsViolatedTest {
+        @Test
+        public void shouldFail() {
+        }
+    }
+
+    static class NoPublicTestElementsPassedTest {
+        @Test
+        void shouldPass() {
+        }
+    }
+}

--- a/src/test/java/edu/hm/hafner/util/ArchitectureTest.java
+++ b/src/test/java/edu/hm/hafner/util/ArchitectureTest.java
@@ -1,8 +1,12 @@
 package edu.hm.hafner.util;
 
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.core.importer.Location;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
+
+import edu.hm.hafner.util.ArchitectureTest.DoNotIncludeRulesUnderTest;
 
 /**
  * Checks the architecture of this module.
@@ -10,7 +14,7 @@ import com.tngtech.archunit.lang.ArchRule;
  * @author Ullrich Hafner
  */
 @SuppressWarnings("hideutilityclassconstructor")
-@AnalyzeClasses(packages = "edu.hm.hafner")
+@AnalyzeClasses(packages = "edu.hm.hafner", importOptions = DoNotIncludeRulesUnderTest.class)
 class ArchitectureTest {
     @ArchTest
     static final ArchRule NO_PUBLIC_TEST_CLASSES = ArchitectureRules.NO_PUBLIC_TEST_CLASSES;
@@ -35,4 +39,13 @@ class ArchitectureTest {
 
     @ArchTest
     static final ArchRule NO_EXCEPTIONS_WITH_NO_ARG_CONSTRUCTOR = ArchitectureRules.NO_EXCEPTIONS_WITH_NO_ARG_CONSTRUCTOR;
+
+    static final class DoNotIncludeRulesUnderTest implements ImportOption {
+        DoNotIncludeRulesUnderTest() {
+        }
+
+        public boolean includes(final Location location) {
+            return !location.contains(ArchitectureRulesTest.class.getSimpleName());
+        }
+    }
 }


### PR DESCRIPTION
Provides tests for the rules:
- `ArchitectureRules.NO_PUBLIC_TEST_CLASSES`
- `ArchitectureRules.ONLY_PACKAGE_PRIVATE_TEST_METHODS`