### PR TITLE
Replaced deprecated and now broken `ReaderInputStream` constructor call

### DIFF
--- a/src/main/java/edu/hm/hafner/util/SecureXmlParserFactory.java
+++ b/src/main/java/edu/hm/hafner/util/SecureXmlParserFactory.java
@@ -306,8 +306,9 @@ public class SecureXmlParserFactory {
         }
     }
 
-    private InputSource createInputSource(final Reader reader, final Charset charset) {
-        return new InputSource(new ReaderInputStream(reader, charset));
+    private InputSource createInputSource(final Reader reader, final Charset charset) throws IOException {
+        var inputStream = ReaderInputStream.builder().setCharset(charset).setReader(reader).get();
+        return new InputSource(inputStream);
     }
 
     /**


### PR DESCRIPTION
See broken https://github.com/jenkinsci/analysis-model/pull/923.