### PR TITLE
Revert commons-io to 2.11.0

### DIFF
--- a/etc/pmd-configuration.xml
+++ b/etc/pmd-configuration.xml
@@ -31,6 +31,7 @@
     <exclude name="OnlyOneReturn"/>
     <exclude name="EmptyMethodInAbstractClassShouldBeAbstract"/>
     <exclude name="ConfusingTernary"/>
+    <exclude name="LocalVariableNamingConventions"/>
     <exclude name="ClassNamingConventions"/>
   </rule>
   <rule ref="category/java/codestyle.xml/UnnecessaryConstructor">

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- Project Dependencies Configuration -->
     <spotbugs.version>4.7.3</spotbugs.version>
     <commons.lang.version>3.13.0</commons.lang.version>
-    <commons.io.version>2.14.0</commons.io.version>
+    <commons.io.version>2.11.0</commons.io.version>
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <byte-buddy.version>1.14.8</byte-buddy.version>
 

--- a/src/main/java/edu/hm/hafner/util/SecureXmlParserFactory.java
+++ b/src/main/java/edu/hm/hafner/util/SecureXmlParserFactory.java
@@ -306,9 +306,8 @@ public class SecureXmlParserFactory {
         }
     }
 
-    private InputSource createInputSource(final Reader reader, final Charset charset) throws IOException {
-        var inputStream = ReaderInputStream.builder().setCharset(charset).setReader(reader).get();
-        return new InputSource(inputStream);
+    private InputSource createInputSource(final Reader reader, final Charset charset) {
+        return new InputSource(new ReaderInputStream(reader, charset));
     }
 
     /**


### PR DESCRIPTION
We need to wait for Jenkins LTS 2.426.1, since previous Jenkins versions do not include that update yet.