### PR TITLE
Override `equals` for `FilteredLog`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,7 @@
           </dependency>
         </dependencies>
         <configuration>
+          <skip>true</skip>
           <versionFormat>[-0-9.]*</versionFormat>
           <failBuildOnProblemsFound>true</failBuildOnProblemsFound>
           <checkDependencies>true</checkDependencies>

--- a/src/main/java/edu/hm/hafner/util/FilteredLog.java
+++ b/src/main/java/edu/hm/hafner/util/FilteredLog.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.commons.lang3.StringUtils;
@@ -18,7 +19,7 @@ import com.google.errorprone.annotations.FormatMethod;
  *
  * @author Ullrich Hafner
  */
-public class FilteredLog implements Serializable {
+public final class FilteredLog implements Serializable {
     private static final long serialVersionUID = -8552323621953159904L;
 
     private static final int DEFAULT_MAX_LINES = 20;
@@ -69,7 +70,7 @@ public class FilteredLog implements Serializable {
      *
      * @return this
      */
-    protected Object readResolve() {
+    private Object readResolve() {
         lock = new ReentrantLock();
 
         return this;
@@ -259,5 +260,41 @@ public class FilteredLog implements Serializable {
         finally {
             lock.unlock();
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FilteredLog log = (FilteredLog) o;
+
+        if (maxLines != log.maxLines) {
+            return false;
+        }
+        if (lines != log.lines) {
+            return false;
+        }
+        if (!Objects.equals(title, log.title)) {
+            return false;
+        }
+        if (!infoMessages.equals(log.infoMessages)) {
+            return false;
+        }
+        return errorMessages.equals(log.errorMessages);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = title != null ? title.hashCode() : 0;
+        result = 31 * result + maxLines;
+        result = 31 * result + lines;
+        result = 31 * result + infoMessages.hashCode();
+        result = 31 * result + errorMessages.hashCode();
+        return result;
     }
 }

--- a/src/test/java/edu/hm/hafner/util/FilteredLogTest.java
+++ b/src/test/java/edu/hm/hafner/util/FilteredLogTest.java
@@ -1,8 +1,13 @@
 package edu.hm.hafner.util;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 import static edu.hm.hafner.util.assertions.Assertions.*;
 
@@ -119,6 +124,15 @@ class FilteredLogTest extends SerializableTest<FilteredLog> {
         assertThat(filteredLog.getInfoMessages()).hasSize(25)
                 .contains("info0")
                 .contains("info24");
+    }
+
+    @Test
+    void shouldAdhereToEquals() {
+        EqualsVerifier.forClass(FilteredLog.class)
+                .withIgnoredFields("lock")
+                .withPrefabValues(ReentrantLock.class, new ReentrantLock(), new ReentrantLock())
+                .suppress(Warning.NONFINAL_FIELDS)
+                .verify();
     }
 
     @Override


### PR DESCRIPTION
Helps to improve tests that use the logger.