### PR TITLE
Deactivate LiteralsFirstInComparisons PMD rule.

### DIFF
--- a/etc/pmd-configuration.xml
+++ b/etc/pmd-configuration.xml
@@ -7,6 +7,7 @@
   <description>Ullrich Hafner's PMD rules</description>
 
   <rule ref="category/java/bestpractices.xml">
+    <exclude name="LiteralsFirstInComparisons"/>
     <exclude name="JUnitTestContainsTooManyAsserts"/>
     <exclude name="JUnitTestsShouldIncludeAssert"/>
     <exclude name="JUnitAssertionsShouldIncludeMessage"/>


### PR DESCRIPTION
It makes more sense to avoid the [Yoda Condition](https://errorprone.info/bugpattern/YodaCondition).