### PR TITLE
Add CheckStyle checks to ensure no empty lines

### DIFF
--- a/etc/checkstyle-configuration.xml
+++ b/etc/checkstyle-configuration.xml
@@ -8,6 +8,14 @@
         "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
   <property name="severity" value="warning"/>
+  <module name="RegexpMultiline">
+    <property name="format" value="\{\s*\R\s*\R"/>
+    <property name="message" value="No empty lines after opening curly braces allowed" />
+  </module>
+  <module name="RegexpMultiline">
+    <property name="format" value="\R\s*\R\s*\}"/>
+    <property name="message" value="No empty lines before closing curly braces allowed" />
+  </module>
   <module name="TreeWalker">
     <module name="SuppressWarningsHolder" />
 

--- a/src/main/java/edu/hm/hafner/util/Ensure.java
+++ b/src/main/java/edu/hm/hafner/util/Ensure.java
@@ -653,7 +653,6 @@ public final class Ensure {
             if (!type.isInstance(value)) {
                 throwException(explanation, args);
             }
-
         }
     }
 

--- a/src/main/java/edu/hm/hafner/util/PathUtil.java
+++ b/src/main/java/edu/hm/hafner/util/PathUtil.java
@@ -174,7 +174,6 @@ public class PathUtil {
                 return makeUnixPath(normalizedBase.relativize(normalize(path)).toString());
             }
             return makeUnixPath(normalizedBase.relativize(normalize(base.resolve(path))).toString());
-
         }
         catch (IOException | IllegalArgumentException ignored) {
             // ignore and return the path as such

--- a/src/test/java/edu/hm/hafner/util/ArchitectureRules.java
+++ b/src/test/java/edu/hm/hafner/util/ArchitectureRules.java
@@ -165,7 +165,6 @@ public final class ArchitectureRules {
         private boolean isVisibleForTesting(final CanBeAnnotated target) {
             return target.isAnnotatedWith(VisibleForTesting.class);
         }
-
     }
 
     /**
@@ -200,7 +199,6 @@ public final class ArchitectureRules {
         private boolean isPermittedException(final JavaClass owner) {
             return allowedExceptions.stream().anyMatch(owner::isAssignableTo);
         }
-
     }
 
     private static class ShouldBeProtectedCondition extends ArchCondition<JavaMethod> {


### PR DESCRIPTION
- There should be no empty line right after an opening curly brace.
- There should be no empty line right before a closing curly brace.