### PR TITLE
Ignore `ParameterNumber` check for overridden methods

### DIFF
--- a/etc/checkstyle-java-configuration.xml
+++ b/etc/checkstyle-java-configuration.xml
@@ -82,7 +82,9 @@
       <property name="max" value="10"/>
     </module>
     <module name="MethodLength"/>
-    <module name="ParameterNumber"/>
+    <module name="ParameterNumber">
+      <property name="ignoreOverriddenMethods" value="true"/>
+    </module>
     <module name="EmptyForIteratorPad"/>
     <module name="EmptyLineSeparator">
       <property name="allowMultipleEmptyLines" value="false"/>

--- a/etc/checkstyle-tests-configuration.xml
+++ b/etc/checkstyle-tests-configuration.xml
@@ -82,7 +82,9 @@
       <property name="max" value="10"/>
     </module>
     <module name="MethodLength"/>
-    <module name="ParameterNumber"/>
+    <module name="ParameterNumber">
+      <property name="ignoreOverriddenMethods" value="true"/>
+    </module>
     <module name="EmptyForIteratorPad"/>
     <module name="EmptyLineSeparator">
       <property name="allowMultipleEmptyLines" value="false"/>


### PR DESCRIPTION
It makes no sense to warn about the parameters in overridden methods.