### PR TITLE
Skip the default invocation of `pmd` when using the `check` goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -552,6 +552,7 @@
         <configuration>
           <linkXRef>false</linkXRef>
           <targetJdk>${java.version}</targetJdk>
+          <skip>true</skip>
         </configuration>
         <dependencies>
           <dependency>
@@ -586,6 +587,7 @@
               </rulesets>
               <includeTests>false</includeTests>
               <minimumTokens>50</minimumTokens>
+              <skip>false</skip>
             </configuration>
           </execution>
           <execution>
@@ -608,6 +610,7 @@
                 <excludeRoot>${project.build.directory}/generated-test-sources/test-annotations</excludeRoot>
                 <excludeRoot>${project.build.directory}/generated-test-sources/assertj-assertions</excludeRoot>
               </excludeRoots>
+              <skip>false</skip>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
When we apply the [different PMD rulesets guide](https://maven.apache.org/plugins/maven-pmd-plugin/examples/differentRulesetForTests.html) in combination with the maven check goal then PMD is invoked three times: one time for the production code, one time for the test code, and one time for the check goal with the default configuration. The last invocation makes no sense and needs to be removed so that additional pipeline scripts correctly visualize the PMD results.
