### PR TITLE
Do not hide "return value ignored" violations in tests

### DIFF
--- a/etc/spotbugs-exclusion-filter.xml
+++ b/etc/spotbugs-exclusion-filter.xml
@@ -23,7 +23,7 @@
     <Class name="~.*Assert" />
   </Match>
   <Match>
-    <Bug code="UuF, UwF, SIC, NP, Dm, UI, RV, DMI, EI, THROWS" />
+    <Bug code="UuF, UwF, SIC, NP, Dm, UI, DMI, EI, THROWS" />
     <Class name="~.*(Test|Benchmark).*" />
   </Match>
   <Match>


### PR DESCRIPTION
Otherwise a wrong usage of Assertj will not be flagged by SpotBugs.