### PR TITLE
Print PMD warnings in Maven log as well

### DIFF
--- a/docker/images/jenkins-controller/jenkins.yaml
+++ b/docker/images/jenkins-controller/jenkins.yaml
@@ -13,7 +13,6 @@ jenkins:
     rawHtml:
       disableSyntaxHighlighting: false
   mode: NORMAL
-  myViewsTabBar: "standard"
   nodes:
     - permanent:
         labelString: "docker linux agent java jdk21 java21"

--- a/etc/pmd-java-configuration.xml
+++ b/etc/pmd-java-configuration.xml
@@ -31,6 +31,7 @@
     <exclude name="EmptyControlStatement"/>
     <exclude name="EmptyMethodInAbstractClassShouldBeAbstract"/>
     <exclude name="FieldDeclarationsShouldBeAtStartOfClass"/>
+    <exclude name="LambdaCanBeMethodReference"/>
     <exclude name="LocalVariableCouldBeFinal"/>
     <exclude name="LocalVariableNamingConventions"/>
     <exclude name="LongVariable"/>

--- a/pom.xml
+++ b/pom.xml
@@ -810,6 +810,7 @@
               </rulesets>
               <includeTests>false</includeTests>
               <minimumTokens>50</minimumTokens>
+              <printFailingErrors>true</printFailingErrors>
               <skip>${pmd.skip}</skip>
             </configuration>
           </execution>
@@ -828,6 +829,7 @@
               </rulesets>
               <includeTests>true</includeTests>
               <minimumTokens>100</minimumTokens>
+              <printFailingErrors>true</printFailingErrors>
               <excludeRoots>
                 <excludeRoot>src/main/java</excludeRoot>
                 <excludeRoot>${project.build.directory}/generated-test-sources/test-annotations</excludeRoot>


### PR DESCRIPTION
Show warnings in the log like:

```
[INFO] <<< pmd:3.26.0:check (run-pmd-tests) < :pmd @ java2-abgabe7 <<<
[INFO] 
[INFO] 
[INFO] --- pmd:3.26.0:check (run-pmd-tests) @ java2-abgabe7 ---
[WARNING] PMD Failure: edu.hm.hafner.java2.assignment7.PostalCodeFactoryTest:16 Rule:UseUnderscoresInNumericLiterals Priority:3 Number 85567 should separate every third digit with an underscore.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
```