### PR TITLE
Use Sonatype OSS index service with a custom token

### DIFF
--- a/.github/workflows/quality-monitor-build.yml
+++ b/.github/workflows/quality-monitor-build.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Build with Maven
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          OSS_INDEX_TOKEN: ${{ secrets.OSS_INDEX_TOKEN }}
           PIT: ${{ env.PIT }}
         run: |
           mvn -V --color always -ntp clean verify $PIT -Pci -Powasp | tee maven.log

--- a/pom.xml
+++ b/pom.xml
@@ -1095,8 +1095,8 @@
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
             <configuration>
-              <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
               <format>JSON</format>
+              <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
               <ossIndexUsername>ullrich.hafner@gmail.com</ossIndexUsername>
               <!--suppress UnresolvedMavenProperty: credentials are provided during CI -->
               <ossIndexPassword>${env.OSS_INDEX_TOKEN}</ossIndexPassword>


### PR DESCRIPTION
Sonatype now requires authentication while accessing the OSS Index analyzer. The token must be provided as the environment variable `OSS_INDEX_TOKEN`.