### PR TITLE
Restore serialization to use interfaces again

### DIFF
--- a/etc/pmd-java-configuration.xml
+++ b/etc/pmd-java-configuration.xml
@@ -21,7 +21,6 @@
   <rule ref="category/java/bestpractices.xml/LooseCoupling">
     <properties>
       <property name="allowedTypes" value="java.util.Properties, java.util.Stack, java.util.jar.Attributes, net.minidev.json.JSONArray, hudson.util.ListBoxModel, hudson.util.ComboBoxModel, hudson.DescriptorExtensionList, hudson.EnvVars,  org.jsoup.select.Elements, edu.hm.hafner.util.LineRangeList" />
-      <property name="violationSuppressXPath" value="./ancestor::ClassDeclaration[1][pmd-java:typeIs('java.io.Serializable')]"/>
     </properties>
   </rule>
   <rule ref="category/java/codestyle.xml">

--- a/pom.xml
+++ b/pom.xml
@@ -1012,6 +1012,13 @@
                   <classQualifiedName>edu.hm.hafner.util.SuppressMutation.*</classQualifiedName>
                   <justification>PitMute Annotations are not relevant in API</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <regex>true</regex>
+                  <code>java.field.serialVersionUIDUnchanged</code>
+                  <classSimpleName>FilteredLog</classSimpleName>
+                  <justification>We are using the interface which still serializes correctly.</justification>
+                </item>
               </differences>
             </revapi.differences>
             <revapi.versions>

--- a/src/main/java/edu/hm/hafner/util/FilteredLog.java
+++ b/src/main/java/edu/hm/hafner/util/FilteredLog.java
@@ -31,10 +31,10 @@ public class FilteredLog implements Serializable {
     private final int maxLines;
     private int lines;
 
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final ArrayList<String> infoMessages = new ArrayList<>();
-    @SuppressWarnings("PMD.LooseCoupling")
-    private final ArrayList<String> errorMessages = new ArrayList<>();
+    @SuppressWarnings("serial")
+    private final List<String> infoMessages = new ArrayList<>();
+    @SuppressWarnings("serial")
+    private final List<String> errorMessages = new ArrayList<>();
 
     private transient ReentrantLock lock = new ReentrantLock();
 


### PR DESCRIPTION
Changing the fields to serializable classes breaks the existing serializations.