### PR TITLE
Deactivate OSS-Index Analyzer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1123,6 +1123,7 @@
               <format>JSON</format>
               <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
               <ossIndexAnalyzerEnabled>false</ossIndexAnalyzerEnabled>
+              <ossIndexWarnOnlyOnRemoteErrors>true</ossIndexWarnOnlyOnRemoteErrors>
             </configuration>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1122,9 +1122,7 @@
             <configuration>
               <format>JSON</format>
               <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
-              <ossIndexUsername>ullrich.hafner@gmail.com</ossIndexUsername>
-              <!--suppress UnresolvedMavenProperty: credentials are provided during CI -->
-              <ossIndexPassword>${env.OSS_INDEX_TOKEN}</ossIndexPassword>
+              <ossIndexAnalyzerEnabled>false</ossIndexAnalyzerEnabled>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
The OSS-Index Analyzer is now behind a paywall and requires a plan.