### PR TITLE
Add a rule to check for non-private instance fields

### DIFF
--- a/doc/uml/class-diagram-technical.puml
+++ b/doc/uml/class-diagram-technical.puml
@@ -90,7 +90,7 @@ note "Klasse" as Class
 note "Interface" as Interface
 note "Vererbung" as Vererbung
 note "Implementierung" as Implementierung
-note "gerichtete Assoziation" as Assoziation
+note "gerichtete Assoziation\n    als Objektvariable" as Assoziation
 note "Vererbung und dabei\ngenerischen Typ binden" as Generics
 note "gerichtete Abhängigkeit:\n<<use>> benutzt\n<<create>> erzeugt\n<<call>> Aufruf" as Dependency
 note "Aggregation" as Aggregation

--- a/src/test/java/edu/hm/hafner/archunit/ArchitectureRules.java
+++ b/src/test/java/edu/hm/hafner/archunit/ArchitectureRules.java
@@ -32,6 +32,11 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
  * @author Ullrich Hafner
  */
 public final class ArchitectureRules {
+    /** No class should have non-private instance fields. */
+    public static final ArchRule ONLY_PRIVATE_FIELDS =
+            fields().that().doNotHaveModifier(JavaModifier.STATIC)
+                    .should().bePrivate().allowEmptyShould(true);
+
     /** Tests should not use fields. Recommendation is to use factory methods for stubs and mocks. */
     public static final ArchRule NO_FIELDS_IN_TESTS =
             fields().that().areDeclaredInClassesThat().haveSimpleNameEndingWith("Test")

--- a/src/test/java/edu/hm/hafner/archunit/ArchitectureRulesTest.java
+++ b/src/test/java/edu/hm/hafner/archunit/ArchitectureRulesTest.java
@@ -22,6 +22,16 @@ class ArchitectureRulesTest {
     private static final String BROKEN_CLASS_NAME = ArchitectureRulesViolatedTest.class.getTypeName();
 
     @Test
+    void shouldVerifyThatFieldsArePrivate() {
+        assertThatExceptionOfType(AssertionError.class).isThrownBy(
+                        () -> ArchitectureRules.ONLY_PRIVATE_FIELDS.check(importBrokenClass()))
+                .withMessageContainingAll(BROKEN_CLASS_NAME, "fields that do not have modifier STATIC should be private' was violated");
+
+        assertThatNoException().isThrownBy(
+                () -> ArchitectureRules.ONLY_PRIVATE_FIELDS.check(importPassingClass()));
+    }
+
+    @Test
     void shouldUseProtectedForReadResolve() {
         assertThatExceptionOfType(AssertionError.class).isThrownBy(
                         () -> ArchitectureRules.READ_RESOLVE_SHOULD_BE_PROTECTED.check(importBrokenClass()))
@@ -100,7 +110,7 @@ class ArchitectureRulesTest {
 
     private JavaClasses importPassingClass() {
         return new ClassFileImporter().importClasses(ArchitectureRulesPassedTest.class,
-                ArchitectureRulesAlsoPassedTest.class);
+                ArchitectureRulesAlsoPassedTest.class, ArchitectureRulesPassed.class);
     }
 
     private JavaClasses importBrokenClass() {
@@ -116,6 +126,8 @@ class ArchitectureRulesTest {
     public static class ArchitectureRulesViolatedTest {
         @edu.umd.cs.findbugs.annotations.Nullable
         private final String noNullable = null;
+
+        int nonPrivate;
 
         @Test @Disabled("This test is just there to be used in architecture tests")
         public void shouldFail() {
@@ -187,5 +199,10 @@ class ArchitectureRulesTest {
         protected Object readResolve() {
             return this;
         }
+    }
+
+    @SuppressWarnings("all") // This class is just there to be used in architecture tests
+    static class ArchitectureRulesPassed {
+        private int privateField;
     }
 }


### PR DESCRIPTION
One important consequence of information hiding is to make fields of classes always private. This should be enforced with an architecture rule.